### PR TITLE
refator: Aprimoração  scan (httpx, ffuf),  config externa (Viper) e v…

### DIFF
--- a/backend/config.yaml
+++ b/backend/config.yaml
@@ -1,0 +1,31 @@
+server:
+  port: "8080"
+
+outputDirectoryBase: "resultados"
+
+wordlists:
+  ffuf: "/usr/share/seclists/Discovery/DNS/subdomains-top1million-5000.txt"
+
+tools:
+  subfinder:
+    path: "subfinder"
+  assetfinder:
+    path: "assetfinder"
+  curl:
+    path: "curl"
+  jq:
+    path: "jq"
+  sed:
+    path: "sed"
+  ffuf:
+    path: "ffuf"
+    threads: 40
+    matchCodes: "200,301,302,307,403"
+  httpx:
+    path: "httpx"
+    threads: 50
+    matchCodes: "200,301,302,307"
+    timeout: 10000
+  gowitness:
+    path: "gowitness"
+    threads: 4

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -1,0 +1,105 @@
+package config
+
+import (
+	"strings"
+
+	"github.com/romfe89/inviscan/backend/utils"
+	"github.com/spf13/viper"
+)
+
+type Config struct {
+	Server struct {
+		Port string `mapstructure:"port"`
+	} `mapstructure:"server"`
+	OutputDirectoryBase string `mapstructure:"outputDirectoryBase"`
+	Wordlists           struct {
+		Ffuf string `mapstructure:"ffuf"`
+	} `mapstructure:"wordlists"`
+	Tools struct {
+		Subfinder struct {
+			Path string `mapstructure:"path"`
+		} `mapstructure:"subfinder"`
+		Assetfinder struct {
+			Path string `mapstructure:"path"`
+		} `mapstructure:"assetfinder"`
+		Curl struct {
+			Path string `mapstructure:"path"`
+		} `mapstructure:"curl"`
+		Jq struct {
+			Path string `mapstructure:"path"`
+		} `mapstructure:"jq"`
+		Sed struct {
+			Path string `mapstructure:"path"`
+		} `mapstructure:"sed"`
+		Ffuf struct {
+			Path       string `mapstructure:"path"`
+			Threads    int    `mapstructure:"threads"`
+			MatchCodes string `mapstructure:"matchCodes"`
+		} `mapstructure:"ffuf"`
+		Httpx struct {
+			Path       string `mapstructure:"path"`
+			Threads    int    `mapstructure:"threads"`
+			MatchCodes string `mapstructure:"matchCodes"`
+			Timeout    int    `mapstructure:"timeout"`
+		} `mapstructure:"httpx"`
+		Gowitness struct {
+			Path    string `mapstructure:"path"`
+			Threads int    `mapstructure:"threads"`
+		} `mapstructure:"gowitness"`
+	} `mapstructure:"tools"`
+}
+
+var AppConfig Config
+
+func LoadConfig() error {
+	viper.SetConfigName("config")
+	viper.SetConfigType("yaml")
+	viper.AddConfigPath(".")
+	viper.AddConfigPath("./config")
+	viper.AddConfigPath("/etc/inviscan/")
+	viper.AddConfigPath("$HOME/.inviscan")
+
+	viper.SetDefault("server.port", "8080")
+	viper.SetDefault("outputDirectoryBase", "resultados")
+	viper.SetDefault("wordlists.ffuf", "/usr/share/seclists/Discovery/DNS/subdomains-top1million-5000.txt")
+	viper.SetDefault("tools.subfinder.path", "subfinder")
+	viper.SetDefault("tools.assetfinder.path", "assetfinder")
+	viper.SetDefault("tools.curl.path", "curl")
+	viper.SetDefault("tools.jq.path", "jq")
+	viper.SetDefault("tools.sed.path", "sed")
+	viper.SetDefault("tools.ffuf.path", "ffuf")
+	viper.SetDefault("tools.ffuf.threads", 40)
+	viper.SetDefault("tools.ffuf.matchCodes", "200,301,302,307,403")
+	viper.SetDefault("tools.httpx.path", "httpx")
+	viper.SetDefault("tools.httpx.threads", 50)
+	viper.SetDefault("tools.httpx.matchCodes", "200,301,302,307")
+	viper.SetDefault("tools.httpx.timeout", 5000)
+	viper.SetDefault("tools.gowitness.path", "gowitness")
+	viper.SetDefault("tools.gowitness.threads", 4)
+
+	viper.SetEnvPrefix("INVISCAN")
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.AutomaticEnv()
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			utils.LogWarn("Arquivo de configuração não encontrado. Usando padrões e variáveis de ambiente.")
+		} else {
+			utils.LogError("Erro ao ler arquivo de configuração: " + err.Error())
+			return err
+		}
+	} else {
+		utils.LogInfo("Usando arquivo de configuração: " + viper.ConfigFileUsed())
+	}
+
+	err := viper.Unmarshal(&AppConfig)
+	if err != nil {
+		utils.LogError("Erro ao fazer unmarshal da configuração: " + err.Error())
+		return err
+	}
+	return nil
+}
+
+func GetConfig() *Config {
+	return &AppConfig
+}

--- a/backend/config/validate.go
+++ b/backend/config/validate.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/romfe89/inviscan/backend/utils"
+)
+
+func CheckTools(cfg *Config) error {
+	utils.LogInfo("Verificando existência das ferramentas configuradas...")
+
+	toolsToCheck := map[string]string{
+		"subfinder":   cfg.Tools.Subfinder.Path,
+		"assetfinder": cfg.Tools.Assetfinder.Path,
+		"curl":        cfg.Tools.Curl.Path,
+		"jq":          cfg.Tools.Jq.Path,
+		"sed":         cfg.Tools.Sed.Path,
+		"ffuf":        cfg.Tools.Ffuf.Path,
+		"httpx":       cfg.Tools.Httpx.Path,
+		"gowitness":   cfg.Tools.Gowitness.Path,
+	}
+
+	var missingTools []string
+
+	for name, path := range toolsToCheck {
+		if path == "" {
+			missingTools = append(missingTools, fmt.Sprintf("%s (path não configurado!)", name))
+			continue
+		}
+		_, err := exec.LookPath(path)
+		if err != nil {
+			utils.LogWarn(fmt.Sprintf("Ferramenta '%s' NÃO encontrada no path configurado ('%s'): %v", name, path, err))
+			missingTools = append(missingTools, fmt.Sprintf("%s (em '%s')", name, path))
+		} else {
+			
+		}
+	}
+
+	if len(missingTools) > 0 {
+		return fmt.Errorf("as seguintes ferramentas essenciais não foram encontradas ou não são executáveis: %s. Verifique a instalação e as configurações 'tools.<tool>.path' no seu config.yaml ou variáveis de ambiente", strings.Join(missingTools, ", "))
+	}
+
+	utils.LogSuccess("Todas as ferramentas essenciais foram encontradas.")
+	return nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -4,17 +4,32 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 
+	"github.com/romfe89/inviscan/backend/config"
 	"github.com/romfe89/inviscan/backend/handlers"
 	"github.com/romfe89/inviscan/backend/utils"
 )
 
 func main() {
+	if err := config.LoadConfig(); err != nil {
+		log.Fatalf("Falha ao carregar configuração: %v", err)
+		os.Exit(1)
+	}
+
+	cfg := config.GetConfig()
+
+	if err := config.CheckTools(cfg); err != nil {
+		utils.LogError("Erro de validação das ferramentas:")
+		log.Fatalf("Erro: %v", err)
+	}
+
 	http.HandleFunc("/api/ping", handlers.PingHandler)
 	http.HandleFunc("/api/scan", handlers.ScanHandler)
 	http.HandleFunc("/api/results", handlers.ResultsHandler)
 
-	port := "8080"
+	port := cfg.Server.Port
 	utils.LogSuccess(fmt.Sprintf("Servidor backend rodando em http://localhost:%s", port))
+
 	log.Fatal(http.ListenAndServe(":"+port, nil))
 }

--- a/backend/scans/allScans.go
+++ b/backend/scans/allScans.go
@@ -3,50 +3,65 @@ package scans
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
+	"github.com/romfe89/inviscan/backend/config"
 	"github.com/romfe89/inviscan/backend/utils"
 )
 
 func RunFullScan(domain string) error {
 	utils.LogInfo(fmt.Sprintf("Iniciando scan para: %s", domain))
+	cfg := config.GetConfig()
 
 	baseDomain := strings.TrimPrefix(domain, "www.")
 	utils.LogInfo(fmt.Sprintf("Domínio base utilizado: %s", baseDomain))
 
-	outputDir := fmt.Sprintf("resultados/%s_%s", domain, utils.Timestamp())
-	os.MkdirAll(outputDir, 0755)
+	outputDirBase := cfg.OutputDirectoryBase
+	outputDir := filepath.Join(outputDirBase, fmt.Sprintf("%s_%s", domain, utils.Timestamp()))
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		utils.LogError(fmt.Sprintf("Erro crítico ao criar diretório de saída %s: %v", outputDir, err))
+		return fmt.Errorf("falha ao criar diretório de saída: %v", err)
+	}
+	utils.LogInfo(fmt.Sprintf("Resultados serão salvos em: %s", outputDir))
 
 	subdomains, err := EnumerateSubdomains(baseDomain)
 	if err != nil {
-		return err
+		utils.LogError(fmt.Sprintf("Erro na enumeração inicial de subdomínios: %v", err))
 	}
-	utils.LogSuccess(fmt.Sprintf("Total de subdomínios encontrados: %d", len(subdomains)))
+	utils.LogSuccess(fmt.Sprintf("Enumeração inicial encontrou: %d subdomínios", len(subdomains)))
 
-	if ffufOut, err := RunFFUF(baseDomain, outputDir); err == nil {
+	if ffufOut, err := RunFFUF(baseDomain, outputDir); err != nil {
+		utils.LogError(fmt.Sprintf("Erro ao executar ffuf: %v", err))
+	} else if len(ffufOut) > 0 {
+		originalCount := len(subdomains)
 		subdomains = append(subdomains, ffufOut...)
 		subdomains = removeDuplicates(subdomains)
-		utils.LogSuccess(fmt.Sprintf("Subdomínios encontrados: %d", len(subdomains)))
+		utils.LogSuccess(fmt.Sprintf("Adicionados %d subdomínios via ffuf (Total: %d)", len(subdomains)-originalCount, len(subdomains)))
+	}
+
+	subdomainsFile := filepath.Join(outputDir, "subdomains.txt")
+	if err := os.WriteFile(subdomainsFile, []byte(strings.Join(subdomains, "\n")), 0644); err != nil {
+		utils.LogWarn(fmt.Sprintf("Erro ao salvar subdomains.txt: %v", err))
 	}
 
 	active, err := ProbeActiveSites(subdomains, outputDir)
 	if err != nil {
-		return fmt.Errorf("erro ao verificar sites ativos: %v", err)
+		utils.LogError(fmt.Sprintf("Erro ao verificar sites ativos: %v", err))
+	} else {
+		utils.LogSuccess(fmt.Sprintf("Sites ativos encontrados: %d", len(active)))
 	}
-	utils.LogSuccess(fmt.Sprintf("Sites ativos encontrados: %d", len(active)))
 
 	juicy := FilterJuicyTargets(active, outputDir)
-	utils.LogSuccess(fmt.Sprintf("Juicy targets encontrados: %d", len(juicy)))
 
 	if err := CaptureScreenshots(active, outputDir); err != nil {
-		return fmt.Errorf("erro ao capturar screenshots: %v", err)
+		utils.LogError(fmt.Sprintf("Erro ao capturar screenshots: %v", err))
 	}
 
 	if err := CompareWithPrevious(domain, subdomains, outputDir); err != nil {
-		return fmt.Errorf("erro na comparação: %v", err)
+		utils.LogError(fmt.Sprintf("Erro na comparação com scan anterior: %v", err))
 	}
 
-	utils.LogSuccess(fmt.Sprintf("Scan concluído: %d subdomínios | %d ativos | %d juicy", len(subdomains), len(active), len(juicy)))
-	utils.LogSuccess(fmt.Sprintf("Scan concluído para: %s", domain))
+	utils.LogSuccess(fmt.Sprintf("Scan concluído para %s: %d subdomínios | %d ativos | %d juicy", domain, len(subdomains), len(active), len(juicy)))
 	return nil
 }

--- a/backend/scans/ffuf.go
+++ b/backend/scans/ffuf.go
@@ -6,72 +6,104 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/romfe89/inviscan/backend/config"
 	"github.com/romfe89/inviscan/backend/utils"
 )
 
 type ffufResult struct {
 	Results []struct {
-		Input map[string]string `json:"input"`
-		Host  string            `json:"host"`
+		Input  map[string]string `json:"input"`
+		Host   string            `json:"host"`
+		URL    string            `json:"url"`
+		Status int64             `json:"status"`
 	} `json:"results"`
 }
 
 func RunFFUF(domain string, outputDir string) ([]string, error) {
+	cfg := config.GetConfig()
 	utils.LogInfo("Enumerando subdomínios com ffuf...")
 
-	wordlist := "/snap/seclists/900/Discovery/DNS/subdomains-top1million-5000.txt"
+	wordlist := cfg.Wordlists.Ffuf
 	if _, err := os.Stat(wordlist); err != nil {
-		utils.LogWarn(fmt.Sprintf("Wordlist não encontrada: %s", wordlist))
-		return nil, nil
+		utils.LogError(fmt.Sprintf("Wordlist ffuf não encontrada em %s (configurado em wordlists.ffuf).", wordlist))
+		return nil, fmt.Errorf("wordlist ffuf não encontrada em %s", wordlist)
 	}
 
 	outputFile := filepath.Join(outputDir, "ffuf.json")
 	baseDomain := strings.TrimPrefix(domain, "www.")
 
-	cmd := exec.Command("ffuf",
+	cmd := exec.Command(cfg.Tools.Ffuf.Path,
 		"-u", fmt.Sprintf("http://FUZZ.%s", baseDomain),
 		"-w", wordlist,
-		"-mc", "200",
-		"-t", "40",
+		"-mc", cfg.Tools.Ffuf.MatchCodes,
+		"-t", strconv.Itoa(cfg.Tools.Ffuf.Threads),
 		"-of", "json",
 		"-o", outputFile,
 	)
 
-	utils.LogInfo("Comando que será executado:")
+	utils.LogInfo("Comando ffuf que será executado:")
 	utils.LogInfo(strings.Join(cmd.Args, " "))
 
-	if err := cmd.Run(); err != nil {
-		utils.LogWarn(fmt.Sprintf("ffuf falhou: %v", err))
-		return nil, nil
+	outputBytes, err := cmd.CombinedOutput()
+	if err != nil {
+		utils.LogWarn(fmt.Sprintf("ffuf falhou ou terminou com avisos. Código de saída pode não ser 0. Erro: %v", err))
+		utils.LogWarn(fmt.Sprintf("Saída do ffuf (stdout/stderr):\n%s", string(outputBytes)))
 	}
 
 	data, err := os.ReadFile(outputFile)
 	if err != nil {
-		utils.LogWarn(fmt.Sprintf("Erro ao ler %s: %v", outputFile, err))
+		utils.LogWarn(fmt.Sprintf("Erro ao ler arquivo de resultado do ffuf %s: %v.", outputFile, err))
 		return nil, nil
 	}
 	if len(data) == 0 {
-		utils.LogWarn("ffuf não retornou resultados.")
+		utils.LogInfo("Arquivo de resultado do ffuf está vazio (nenhum subdomínio encontrado ou ffuf falhou).")
 		return nil, nil
 	}
 
 	var parsed ffufResult
 	if err := json.Unmarshal(data, &parsed); err != nil {
-		utils.LogWarn(fmt.Sprintf("Erro ao interpretar JSON do ffuf: %v", err))
+		utils.LogWarn(fmt.Sprintf("Erro ao interpretar JSON do ffuf (%s): %v", outputFile, err))
+		utils.LogWarn(fmt.Sprintf("Conteúdo do JSON (início): %s", string(data[:min(len(data), 200)])))
 		return nil, nil
 	}
 
 	var found []string
+	seen := make(map[string]bool)
 	for _, r := range parsed.Results {
+		var subdomain string
 		if r.Host != "" {
-			found = append(found, r.Host)
-		} else if sub, ok := r.Input["FUZZ"]; ok {
-			found = append(found, fmt.Sprintf("%s.%s", sub, baseDomain))
+			subdomain = r.Host
+		} else if sub, ok := r.Input["FUZZ"]; ok && sub != "" {
+			subdomain = fmt.Sprintf("%s.%s", sub, baseDomain)
+		} else if r.URL != "" {
+			urlParts := strings.SplitN(r.URL, "//", 2)
+			if len(urlParts) == 2 {
+				hostAndPath := strings.SplitN(urlParts[1], "/", 2)
+				subdomain = hostAndPath[0]
+			}
+		}
+
+		if subdomain != "" && strings.HasSuffix(subdomain, "."+baseDomain) && !seen[subdomain] {
+			found = append(found, subdomain)
+			seen[subdomain] = true
 		}
 	}
 
-	utils.LogSuccess(fmt.Sprintf("ffuf encontrou %d subdomínios", len(found)))
+	if len(found) > 0 {
+		utils.LogSuccess(fmt.Sprintf("ffuf encontrou %d subdomínios únicos (com status %s)", len(found), cfg.Tools.Ffuf.MatchCodes))
+	} else {
+		utils.LogInfo("ffuf não encontrou novos subdomínios com os critérios atuais.")
+	}
+
 	return found, nil
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }

--- a/backend/scans/juicy.go
+++ b/backend/scans/juicy.go
@@ -11,35 +11,86 @@ import (
 
 func FilterJuicyTargets(sites []string, outputDir string) []string {
 	terms := []string{
-		"dev", "dev1", "dev2", "dev3", "development", "test", "testing", "qa",
-		"staging", "hml", "sandbox", "demo", "preview", "beta", "alpha", "preprod", "uat",
-		"jenkins", "git", "gitlab", "bitbucket", "ci", "cicd", "pipeline", "artifactory", "nexus", "registry",
-		"docker", "harbor", "login", "signin", "auth", "authentication", "sso", "saml", "oauth",
-		"register", "signup", "password", "reset", "forgot", "token", "vpn", "remote", "access", "gateway",
-		"firewall", "admin", "adminpanel", "manage", "dashboard", "console", "cms", "intranet", "internal",
-		"private", "secure", "portal", "support", "help", "helpdesk", "it", "ticket", "jira", "confluence",
-		"servicenow", "db", "database", "mysql", "postgres", "mongo", "sql", "redis",
-		"api", "backend", "tools", "monitoring", "status", "uptime", "metrics", "grafana", "prometheus",
-		"logs", "log", "kibana", "elastic", "public", "static", "files", "uploads", "content", "assets",
-		"media", "old", "backup", "bak", "temp", "tmp", "archive",
+		"dev", "dev1", "dev2", "dev3", "development",
+		"test", "testing", "qa",
+		"staging", "stage",
+		"hml", "homolog",
+		"sandbox",
+		"demo",
+		"preview", "beta", "alpha",
+		"preprod", "uat",
+		"jenkins",
+		"git", "gitlab", "bitbucket", "gitea", "gogs",
+		"ci", "cicd", ".ci.", "-ci-", "pipeline",
+		"artifactory", "nexus", "registry", "harbor",
+		"docker",
+		"tools", "tooling", "util",
+		"jira", "confluence", "youtrack",
+		"swagger", "openapi", "postman",
+		"login", "signin", "logon",
+		"auth", "authentication", "authenticate",
+		"sso", "saml", "oauth", "oidc", "kerberos",
+		"register", "signup",
+		"password", "passwd", "pwd", "reset", "forgot",
+		"token", "jwt", "session",
+		"vpn", "remote", "access", "gateway", "rdp",
+		"firewall", "proxy",
+		"admin", "administrator", "adm",
+		"adminpanel", "panel", "manage", "manager",
+		"dashboard", "dash", "board",
+		"console", "control", "webconsole",
+		"cms", "wordpress", "wp-admin", "drupal", "joomla",
+		"intranet", "internal", "corp", "private",
+		"secure",
+		"portal",
+		"support", "help", "helpdesk", "servicedesk",
+		"it", "itsm",
+		"ticket", "osticket", "zammad", "zendesk",
+		"servicenow",
+		"db", "database",
+		"sql", "mysql", "postgres", "pgsql", "mssql",
+		"mongo", "mongodb", "redis", "nosql",
+		"api", "api-docs", "graphql", "rest",
+		"backend", "internal-api",
+		"monitoring", "monitor", "metrics", "stats", "status", "health", "uptime",
+		"grafana", "prometheus", "zabbix", "nagios", "icinga",
+		"logs", "log", "logging", "kibana", "elastic", "elasticsearch", "graylog", "splunk",
+		"public",
+		"static", "files", "uploads", "downloads", "content", "assets", "media", "storage",
+		"backup", "bak", "bkp", "dump",
+		"old", "temp", "tmp", "archive", "export", "import",
+		"config", "conf", "settings", "env", ".env",
+		"debug", "trace",
+		"phpmyadmin", "pgadmin",
+		"internal",
 	}
 
 	var juicy []string
+	seenJuicy := make(map[string]bool)
+
 	for _, site := range sites {
+		siteLower := strings.ToLower(site)
 		for _, term := range terms {
-			if strings.Contains(site, term) {
-				juicy = append(juicy, site)
+			if strings.Contains(siteLower, term) {
+				if !seenJuicy[site] {
+					juicy = append(juicy, site)
+					seenJuicy[site] = true
+				}
 				break
 			}
 		}
 	}
 
-	// Salvar juicytargets.txt
 	juicyFile := filepath.Join(outputDir, "juicytargets.txt")
 	if err := os.WriteFile(juicyFile, []byte(strings.Join(juicy, "\n")), 0644); err != nil {
 		utils.LogError(fmt.Sprintf("Erro ao salvar juicytargets.txt: %v", err))
 	}
 
-	utils.LogSuccess(fmt.Sprintf("Juicy targets encontrados: %d", len(juicy)))
+	if len(juicy) > 0 {
+		utils.LogSuccess(fmt.Sprintf("Juicy targets encontrados: %d (salvos em %s)", len(juicy), juicyFile))
+	} else {
+		utils.LogInfo("Nenhum Juicy Target encontrado com os termos atuais.")
+	}
+
 	return juicy
 }

--- a/backend/scans/probing.go
+++ b/backend/scans/probing.go
@@ -7,41 +7,91 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/romfe89/inviscan/backend/config"
 	"github.com/romfe89/inviscan/backend/utils"
 )
 
 func ProbeActiveSites(subdomains []string, outputDir string) ([]string, error) {
-	utils.LogInfo("Verificando sites ativos com httprobe...")
+	cfg := config.GetConfig()
+	utils.LogInfo("Verificando sites ativos com httpx...")
+
+	validSubdomains := filterValidDomains(subdomains)
+	if len(validSubdomains) == 0 {
+		utils.LogWarn("Nenhum subdomínio válido para sondar com httpx.")
+		activeFile := filepath.Join(outputDir, "active_sites.txt")
+		os.WriteFile(activeFile, []byte(""), 0644)
+		return []string{}, nil
+	}
+
+	tempFile, err := os.CreateTemp("", "httpx-input-*.txt")
+	if err != nil {
+		utils.LogError(fmt.Sprintf("Erro ao criar arquivo temporário para httpx: %v", err))
+		return nil, fmt.Errorf("falha ao criar arquivo temporário: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	writer := bufio.NewWriter(tempFile)
+	for _, sub := range validSubdomains {
+		_, _ = writer.WriteString(sub + "\n")
+	}
+	writer.Flush()
+	tempFile.Close()
+
+	utils.LogInfo(fmt.Sprintf("Executando httpx com a lista: %s", tempFile.Name()))
+
+	httpxArgs := []string{
+		"-l", tempFile.Name(),
+		"-silent",
+		"-threads", strconv.Itoa(cfg.Tools.Httpx.Threads),
+		"-prefer-https",
+		"-status-code",
+		"-mc", cfg.Tools.Httpx.MatchCodes,
+	}
+	if cfg.Tools.Httpx.Timeout > 0 {
+		httpxArgs = append(httpxArgs, "-timeout", strconv.Itoa(cfg.Tools.Httpx.Timeout/1000)) // httpx timeout é em segundos
+	}
+
+	cmd := exec.Command(cfg.Tools.Httpx.Path, httpxArgs...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run() // Execução sem timeout
+	if err != nil {
+		utils.LogWarn(fmt.Sprintf("httpx finalizou com erro (pode ser normal): %v", err))
+		errMsg := stderr.String()
+		if errMsg != "" {
+			utils.LogWarn(fmt.Sprintf("httpx stderr: %s", errMsg))
+		}
+	}
 
 	var active []string
-	for _, sub := range filterValidDomains(subdomains) {
-		cmd := exec.Command("httprobe", "-t", "5000")
-		cmd.Stdin = strings.NewReader(sub + "\n")
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-
-		if err := cmd.Run(); err != nil {
-			utils.LogWarn(fmt.Sprintf("httprobe falhou para %s: %s", sub, stderr.String()))
-			continue
-		}
-
-		scanner := bufio.NewScanner(&stdout)
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if line != "" {
+	scanner := bufio.NewScanner(&stdout)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			parts := strings.Split(line, " ")
+			if len(parts) > 0 && (strings.HasPrefix(parts[0], "http://") || strings.HasPrefix(parts[0], "https://")) {
+				active = append(active, parts[0])
+			} else if strings.HasPrefix(line, "http://") || strings.HasPrefix(line, "https://") {
 				active = append(active, line)
 			}
 		}
 	}
 
-	// Salvar os sites ativos no diretório de saída
+	if err := scanner.Err(); err != nil {
+		utils.LogWarn(fmt.Sprintf("Erro ao ler saída do httpx: %v", err))
+	}
+
 	activeFile := filepath.Join(outputDir, "active_sites.txt")
 	if err := os.WriteFile(activeFile, []byte(strings.Join(active, "\n")), 0644); err != nil {
 		utils.LogError(fmt.Sprintf("Erro ao salvar active_sites.txt: %v", err))
+	} else {
+		utils.LogSuccess(fmt.Sprintf("Salvo %d sites ativos em %s", len(active), activeFile))
 	}
 
 	return active, nil
@@ -49,10 +99,14 @@ func ProbeActiveSites(subdomains []string, outputDir string) ([]string, error) {
 
 func filterValidDomains(domains []string) []string {
 	valid := []string{}
+	seen := make(map[string]bool)
 	for _, d := range domains {
-		// ignorar strings vazias, URLs com protocolo e espaços
-		if d != "" && !strings.HasPrefix(d, "http") && !strings.Contains(d, "/") && !strings.Contains(d, " ") {
-			valid = append(valid, d)
+		d = strings.TrimSpace(d)
+		if d != "" && !strings.HasPrefix(d, "http") && !strings.Contains(d, "/") && !strings.Contains(d, " ") && !seen[d] {
+			if !strings.ContainsAny(d, "0123456789") || strings.ContainsAny(d, "abcdefghijklmnopqrstuvwxyz") {
+				valid = append(valid, d)
+				seen[d] = true
+			}
 		}
 	}
 	return valid

--- a/backend/scans/screenshot.go
+++ b/backend/scans/screenshot.go
@@ -5,40 +5,50 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
+	"github.com/romfe89/inviscan/backend/config"
 	"github.com/romfe89/inviscan/backend/utils"
 )
 
 func CaptureScreenshots(sites []string, outputDir string) error {
+	cfg := config.GetConfig()
 	if len(sites) == 0 {
 		utils.LogWarn("Nenhum site ativo para capturar com gowitness.")
 		return nil
 	}
-
-	gowitnessDir := filepath.Join(outputDir, "gowitness")
+	gowitnessParentDir := filepath.Join(cfg.OutputDirectoryBase, filepath.Base(outputDir))
+	gowitnessDir := filepath.Join(gowitnessParentDir, "gowitness")
 	if err := os.MkdirAll(gowitnessDir, 0755); err != nil {
-		utils.LogError(fmt.Sprintf("Erro ao criar diretório gowitness: %v", err))
+		utils.LogError(fmt.Sprintf("Erro ao criar diretório gowitness %s: %v", gowitnessDir, err))
 		return err
 	}
 
 	utils.LogInfo("Preparando targets.txt para gowitness...")
 	targetsPath := filepath.Join(gowitnessDir, "targets.txt")
 	if err := os.WriteFile(targetsPath, []byte(strings.Join(sites, "\n")), 0644); err != nil {
-		utils.LogError(fmt.Sprintf("Erro ao escrever targets.txt: %v", err))
+		utils.LogError(fmt.Sprintf("Erro ao escrever targets.txt em %s: %v", targetsPath, err))
 		return err
 	}
 
 	utils.LogInfo("Executando gowitness scan...")
-	cmd := exec.Command("gowitness", "scan", "file", "-f", "targets.txt", "--threads", "4", "--skip-html")
+	cmd := exec.Command(cfg.Tools.Gowitness.Path,
+		"scan", "file", "-f", "targets.txt",
+		"--threads", strconv.Itoa(cfg.Tools.Gowitness.Threads),
+		"--skip-html",
+	)
 	cmd.Dir = gowitnessDir
 
 	output, err := cmd.CombinedOutput()
+	utils.LogInfo(fmt.Sprintf("Saída do Gowitness:\n%s", string(output)))
+
 	if err != nil {
-		utils.LogWarn(fmt.Sprintf("gowitness retornou erro: %s", string(output)))
+		utils.LogWarn(fmt.Sprintf("gowitness retornou erro: %v", err))
 		return fmt.Errorf("falha ao executar gowitness scan: %v", err)
 	}
 
-	utils.LogSuccess(fmt.Sprintf("Capturas salvas no diretório: %s", filepath.Join(outputDir, "gowitness")))
+	relativeGowitnessDir := filepath.Join(filepath.Base(outputDir), "gowitness")
+	utils.LogSuccess(fmt.Sprintf("Capturas salvas no diretório: %s", relativeGowitnessDir))
 	return nil
 }


### PR DESCRIPTION
refator: Aprimoração do motor de scan do backend e adição do gerenciamento de configuração

Este pull request introduz diversas melhorias ao backend:

- **Ferramentas:**
    - Substituição do `httprobe` pelo `httpx`, mais rico em recursos, para sondar serviços web ativos.
    - Configuração do `ffuf` para aceitar uma gama maior de códigos de status HTTP (`200,301,302,307,403`) para uma descoberta de subdomínios mais abrangente.
    - Expansão e refinação da lista de palavras-chave em `juicy.go` para uma melhor identificação de alvos sensíveis, agora case-insensitive.

- **Configuração:**
    - Adicionado o gerenciamento de configuração usando a biblioteca Viper.
    - Configurações (caminhos de ferramentas, wordlists, threads, timeouts, porta do servidor, diretório de saída) agora são gerenciadas via `config.yaml` e/ou variáveis de ambiente (prefixo `INVISCAN_`).
    - Criado novo pacote `config`.

- **Validação:**
    - Implementada uma checagem na inicialização da aplicação (`config.CheckTools`) para verificar a existência e acessibilidade dos binários das ferramentas externas configuradas.

Estas mudanças tornam o backend mais robusto, flexível, configurável e fácil de configurar em diferentes ambientes.